### PR TITLE
fix 修复this.loader为空的bug

### DIFF
--- a/iast-core/src/main/java/com/secnium/iast/core/enhance/IastClassAncestorQuery.java
+++ b/iast-core/src/main/java/com/secnium/iast/core/enhance/IastClassAncestorQuery.java
@@ -25,7 +25,7 @@ public class IastClassAncestorQuery {
     private static final String BASE_CLASS = "java/lang/Object";
     private final HashSet<String> scannedClassSet = new HashSet<String>();
 
-    public void setLoader(ClassLoader loader) {
+    public synchronized void setLoader(ClassLoader loader) {
         this.loader = loader;
     }
 
@@ -142,10 +142,6 @@ public class IastClassAncestorQuery {
         while (!queue.isEmpty()) {
             String currentClass = queue.poll();
             try {
-                if (null == this.loader) {
-                    break;
-                }
-                //fixme:有时候ClassLoader会为空，先处理一下
                 InputStream inputStream = this.loader.getResourceAsStream(currentClass + ".class");
                 if (inputStream != null) {
                     ClassReader cr = new ClassReader(inputStream);


### PR DESCRIPTION
### 分析
springboot程序启动过程中，`BackgroundPreinitializer`线程或`main`线程调用`IastClassAncestorQuery.scanJarForAncestor`方法,另一个线程之后也调用这个方法，进入阻塞状态。但是如果阻塞前传入`IastClassFileTransformer#transform`方法的类的ClassLoader为`BootstrapClassLoader`的话，会使`COMMON_UTILS.setLoader(loader);`设置`IastClassAncestorQuery#loader`
为null，导致`InputStream inputStream = this.loader.getResourceAsStream(currentClass + ".class");`抛出`java.lang.NullPointerException`。总而言之，这是个线程安全问题。
### 修改描述
- 给`IastClassAncestorQuery#setLoader`添加了`synchronized`关键字
- 去掉了之前处理这个问题的相关代码