### PR TITLE
fix issues-26

### DIFF
--- a/iast-core/src/main/java/com/secnium/iast/core/handler/models/IastHookRuleModel.java
+++ b/iast-core/src/main/java/com/secnium/iast/core/handler/models/IastHookRuleModel.java
@@ -196,7 +196,12 @@ public class IastHookRuleModel {
      */
     public static int getRuleTypeValueByFramework(String framework) {
         if (instance != null) {
-            return instance.hooksValue.get(framework);
+            try {
+                return instance.hooksValue.get(framework);
+            } catch (java.lang.NullPointerException e) {
+                //规则待更新
+                return -1;
+            }
         } else {
             return -1;
         }


### PR DESCRIPTION
### 该Pull Request关联的Issue
#26 
### 分析
`IastHookRuleModel`里的`instance.hooks.get("javax.servlet.http.HttpServlet.service(javax.servlet.http.HttpServletRequest,javax.servlet.http.HttpServletResponse)")`的返回值为`HttpRequest`，而`instance.hooksValue.get("HttpRequest")`的返回值为null。即加载的规则集有待更新。

### 修改描述
try-catcy处理抛出的异常