### PR TITLE
fix 关闭RSA加密功能

### DIFF
--- a/iast-core/src/main/java/com/secnium/iast/core/util/HttpClientUtils.java
+++ b/iast-core/src/main/java/com/secnium/iast/core/util/HttpClientUtils.java
@@ -97,9 +97,10 @@ public class HttpClientUtils {
                 connection.setUseCaches(false);
                 connection.setDoOutput(true);
 
-                String encryptData = RsaUtils.encrypt(data);
+//                String encryptData = RsaUtils.encrypt(data);
                 GZIPOutputStream wr = new GZIPOutputStream(connection.getOutputStream());
-                wr.write(encryptData.getBytes(Charset.forName("UTF-8")));
+//                wr.write(encryptData.getBytes(Charset.forName("UTF-8")));
+                wr.write(data.getBytes(Charset.forName("UTF-8")));
                 wr.close();
             }
             InputStream is = connection.getInputStream();


### PR DESCRIPTION
**场景**
部分环境测试发现，Java的RSA算法在Django中无法还原，导致漏洞无法检出，因此，暂时关闭RSA加密。