### PR TITLE
fix 修复attach方式的问题

### DIFF
--- a/iast-agent/src/main/java/com/secnium/iast/agent/AttachLauncher.java
+++ b/iast-agent/src/main/java/com/secnium/iast/agent/AttachLauncher.java
@@ -18,8 +18,11 @@ public class AttachLauncher {
         try {
             LogUtils.info("trying attach to process " + pid + ", agent address is " + AGENT_PATH);
             vmObj = VirtualMachine.attach(pid);
+            //attach连接上目标vm后，发送指令，让目标vm加载路径为 AGENT_PATH 的agent，可携带参数 token=xxxx
             vmObj.loadAgent(AGENT_PATH, "token=" + args);
             LogUtils.info("attach to process " + pid + " success.");
+            //attach方式主要是发送指令给目标vm执行加载agent的指令，完成后就可以detach了
+            vmObj.detach();
         } catch (AttachNotSupportedException e) {
             LogUtils.error("attach failed, reason: Attach not support");
         } catch (IOException e) {

--- a/iast-agent/src/main/java/com/secnium/iast/agent/manager/EngineManager.java
+++ b/iast-agent/src/main/java/com/secnium/iast/agent/manager/EngineManager.java
@@ -277,7 +277,10 @@ public class EngineManager {
                 classOfEngine.getMethod("destroy", String.class, String.class, Instrumentation.class)
                         .invoke(null, launchMode, this.properties.getPropertiesFilePath(), inst);
                 Agent.appendToolsPath();
-                AttachLauncher.detach(ppid);
+                // 此时的agent已经被加载进目标jvm里了，这个detach多余的，
+                // 如果想让启动时的jar执行detach，在它执行完loadAgent后，就可以detach了。
+                // 这里执行的detach 有点像新建了一个连接，没有执行任何操作就detach了
+                // AttachLauncher.detach(ppid);
             }
         } catch (IllegalAccessException e) {
             e.printStackTrace();


### PR DESCRIPTION
vmObj = VirtualMachine.attach(pid);
//attach连接上目标vm后，发送指令，让目标vm加载路径为 AGENT_PATH 的agent，可携带参数 token=xxxx
vmObj.loadAgent(AGENT_PATH, "token=" + args);
LogUtils.info("attach to process " + pid + " success.");
//attach方式主要是发送指令给目标vm执行加载agent的指令，完成后就可以detach了
vmObj.detach();