### PR TITLE
fix-outofrange

### DIFF
--- a/iast-core/src/main/java/com/secnium/iast/core/replay/HttpRequestReplay.java
+++ b/iast-core/src/main/java/com/secnium/iast/core/replay/HttpRequestReplay.java
@@ -99,9 +99,11 @@ public class HttpRequestReplay extends AbstractThread {
             String[] headerItems = decodeHeaders.trim().split("\n");
             for (String item : headerItems) {
                 int splitCharIndex = item.indexOf(":");
-                String key = item.substring(0, splitCharIndex);
-                String value = item.substring(splitCharIndex + 1);
-                headers.put(key, value);
+                if (splitCharIndex >= 0) {
+                    String key = item.substring(0, splitCharIndex);
+                    String value = item.substring(splitCharIndex + 1);
+                    headers.put(key, value);
+                }
             }
         }
 

--- a/iast-core/src/main/java/com/secnium/iast/core/replay/HttpRequestReplay.java
+++ b/iast-core/src/main/java/com/secnium/iast/core/replay/HttpRequestReplay.java
@@ -99,7 +99,7 @@ public class HttpRequestReplay extends AbstractThread {
             String[] headerItems = decodeHeaders.trim().split("\n");
             for (String item : headerItems) {
                 int splitCharIndex = item.indexOf(":");
-                if (splitCharIndex >= 0) {
+                if (splitCharIndex > 0) {
                     String key = item.substring(0, splitCharIndex);
                     String value = item.substring(splitCharIndex + 1);
                     headers.put(key, value);


### PR DESCRIPTION
java.lang.StringIndexOutOfBoundsException: String index out of range: -1
	at java.lang.String.substring(String.java:1967)
	at com.secnium.iast.core.replay.HttpRequestReplay.splitHeaderStringToHashmap(HttpRequestReplay.java:102)
	at com.secnium.iast.core.replay.HttpRequestReplay.doReplay(HttpRequestReplay.java:80)
	at com.secnium.iast.core.replay.HttpRequestReplay.send(HttpRequestReplay.java:172)
	at com.secnium.iast.core.AbstractThread.run(AbstractThread.java:24)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)