### PR TITLE
Fix stopwatch bug

### DIFF
--- a/dongtai-core/src/main/java/io/dongtai/iast/core/bytecode/enhance/plugin/fallback/FallbackSwitch.java
+++ b/dongtai-core/src/main/java/io/dongtai/iast/core/bytecode/enhance/plugin/fallback/FallbackSwitch.java
@@ -3,6 +3,7 @@ package io.dongtai.iast.core.bytecode.enhance.plugin.fallback;
 import io.dongtai.iast.core.EngineManager;
 import io.dongtai.iast.core.bytecode.enhance.plugin.fallback.report.SecondFallbackReport;
 import io.dongtai.iast.core.bytecode.enhance.plugin.fallback.report.body.SecondFallbackReportBody;
+import io.dongtai.iast.core.utils.StopwatchUtils;
 import io.dongtai.iast.core.utils.config.RemoteConfigUtils;
 import io.dongtai.iast.core.utils.threadlocal.BooleanThreadLocal;
 import io.dongtai.log.DongTaiLog;
@@ -117,17 +118,17 @@ public class FallbackSwitch {
         if (fallback) {
             // 打开开关时，计时器开始计时
             if (stopWatch.isStopped()) {
-                stopWatch.start();
+                StopwatchUtils.start(stopWatch);
             }
         } else {
             if (!stopWatch.isStarted()) {
                 return;
             }
             // 关闭开关时，计时器停止
-            stopWatch.stop();
+            StopwatchUtils.stop(stopWatch);
             // 计算持续时间超限则记录下来
             final long switchOpenStatusDurationThreshold = RemoteConfigUtils.getSwitchOpenStatusDurationThreshold(null);
-            if (stopWatch.getTime() >= switchOpenStatusDurationThreshold) {
+            if (StopwatchUtils.getTime(stopWatch) >= switchOpenStatusDurationThreshold && switchOpenStatusDurationThreshold > 0) {
                 SecondFallbackReport.appendLog(new SecondFallbackReportBody.DurationOverThresholdLog(
                         secondFallbackType, stopWatch, switchOpenStatusDurationThreshold));
             }
@@ -141,12 +142,12 @@ public class FallbackSwitch {
     protected static boolean isNeedSecondFallback() {
         // 1、判断此时流量熔断器开关是否处于打开状态并达到阈值，switchOpenStatusDurationThreshold 不允许为 0，为 0 时会在 stopwatch 未开始状态下触发报错
         long switchOpenStatusDurationThreshold = RemoteConfigUtils.getSwitchOpenStatusDurationThreshold(null);
-        if (HEAVY_TRAFFIC_STOPWATCH.getTime() >= switchOpenStatusDurationThreshold && switchOpenStatusDurationThreshold > 0) {
+        if (StopwatchUtils.getTime(HEAVY_TRAFFIC_STOPWATCH) >= switchOpenStatusDurationThreshold && switchOpenStatusDurationThreshold > 0) {
             SecondFallbackReport.appendLog(new SecondFallbackReportBody.DurationOverThresholdLog(
                     SecondFallbackReasonEnum.TRAFFIC_FALLBACK_DURATION, HEAVY_TRAFFIC_STOPWATCH, switchOpenStatusDurationThreshold));
         }
         // 2、判断此时性能熔断器开关是否处于打开状态并达到阈值
-        if (PERFORMANCE_STOPWATCH.getTime() >= switchOpenStatusDurationThreshold) {
+        if (StopwatchUtils.getTime(PERFORMANCE_STOPWATCH) >= switchOpenStatusDurationThreshold && switchOpenStatusDurationThreshold > 0) {
             SecondFallbackReport.appendLog(new SecondFallbackReportBody.DurationOverThresholdLog(
                     SecondFallbackReasonEnum.PERFORMANCE_FALLBACK_DURATION, PERFORMANCE_STOPWATCH, switchOpenStatusDurationThreshold));
         }

--- a/dongtai-core/src/main/java/io/dongtai/iast/core/bytecode/enhance/plugin/fallback/FallbackSwitch.java
+++ b/dongtai-core/src/main/java/io/dongtai/iast/core/bytecode/enhance/plugin/fallback/FallbackSwitch.java
@@ -140,7 +140,7 @@ public class FallbackSwitch {
      * 判断是否需要二次降级
      */
     protected static boolean isNeedSecondFallback() {
-        // 1、判断此时流量熔断器开关是否处于打开状态并达到阈值，switchOpenStatusDurationThreshold 不允许为 0，为 0 时会在 stopwatch 未开始状态下触发报错
+        // 1、判断此时流量熔断器开关是否处于打开状态并达到阈值，之所以限制 switchOpenStatusDurationThreshold > 0，是因为秒表停止状态下 getTime 的值为 0，如果 switchOpenStatusDurationThreshold < 0 则永远都不会触发二次降级
         long switchOpenStatusDurationThreshold = RemoteConfigUtils.getSwitchOpenStatusDurationThreshold(null);
         if (StopwatchUtils.getTime(HEAVY_TRAFFIC_STOPWATCH) >= switchOpenStatusDurationThreshold && switchOpenStatusDurationThreshold > 0) {
             SecondFallbackReport.appendLog(new SecondFallbackReportBody.DurationOverThresholdLog(

--- a/dongtai-core/src/main/java/io/dongtai/iast/core/bytecode/enhance/plugin/fallback/FallbackSwitch.java
+++ b/dongtai-core/src/main/java/io/dongtai/iast/core/bytecode/enhance/plugin/fallback/FallbackSwitch.java
@@ -139,9 +139,9 @@ public class FallbackSwitch {
      * 判断是否需要二次降级
      */
     protected static boolean isNeedSecondFallback() {
-        // 1、判断此时流量熔断器开关是否处于打开状态并达到阈值
+        // 1、判断此时流量熔断器开关是否处于打开状态并达到阈值，switchOpenStatusDurationThreshold 不允许为 0，为 0 时会在 stopwatch 未开始状态下触发报错
         long switchOpenStatusDurationThreshold = RemoteConfigUtils.getSwitchOpenStatusDurationThreshold(null);
-        if (HEAVY_TRAFFIC_STOPWATCH.getTime() >= switchOpenStatusDurationThreshold) {
+        if (HEAVY_TRAFFIC_STOPWATCH.getTime() >= switchOpenStatusDurationThreshold && switchOpenStatusDurationThreshold > 0) {
             SecondFallbackReport.appendLog(new SecondFallbackReportBody.DurationOverThresholdLog(
                     SecondFallbackReasonEnum.TRAFFIC_FALLBACK_DURATION, HEAVY_TRAFFIC_STOPWATCH, switchOpenStatusDurationThreshold));
         }

--- a/dongtai-core/src/main/java/io/dongtai/iast/core/bytecode/enhance/plugin/fallback/report/body/SecondFallbackReportBody.java
+++ b/dongtai-core/src/main/java/io/dongtai/iast/core/bytecode/enhance/plugin/fallback/report/body/SecondFallbackReportBody.java
@@ -3,6 +3,7 @@ package io.dongtai.iast.core.bytecode.enhance.plugin.fallback.report.body;
 import com.google.gson.annotations.SerializedName;
 import io.dongtai.iast.core.bytecode.enhance.plugin.fallback.FallbackSwitch;
 import io.dongtai.iast.core.handler.hookpoint.vulscan.ReportConstant;
+import io.dongtai.iast.core.utils.StopwatchUtils;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
@@ -144,8 +145,9 @@ public class SecondFallbackReportBody {
 
         public DurationOverThresholdLog(FallbackSwitch.SecondFallbackReasonEnum secondFallbackType, StopWatch stopWatch, Long threshold) {
             super(secondFallbackType);
-            this.startTime = new Date(stopWatch.getStartTime());
-            this.persistTime = stopWatch.getTime();
+            Long startTime = StopwatchUtils.getStartTime(stopWatch);
+            this.startTime = startTime == null ? null : new Date(startTime);
+            this.persistTime = StopwatchUtils.getTime(stopWatch);
             this.threshold = threshold;
         }
     }

--- a/dongtai-core/src/main/java/io/dongtai/iast/core/utils/StopwatchUtils.java
+++ b/dongtai-core/src/main/java/io/dongtai/iast/core/utils/StopwatchUtils.java
@@ -1,0 +1,56 @@
+package io.dongtai.iast.core.utils;
+
+import io.dongtai.log.DongTaiLog;
+import org.apache.commons.lang3.time.StopWatch;
+
+import java.util.Arrays;
+
+/**
+ * 秒表工具类
+ *
+ * @author liyuan40
+ * @date 2022/3/28 11:34
+ */
+public class StopwatchUtils {
+
+    public static void start(StopWatch stopWatch) {
+        try {
+            stopWatch.start();
+        } catch (Exception e) {
+            DongTaiLog.info("Stopwatch.start() method invoke exception.", Arrays.toString(e.getStackTrace()));
+        }
+    }
+
+    public static void stop(StopWatch stopWatch) {
+        try {
+            stopWatch.stop();
+        } catch (Exception e) {
+            DongTaiLog.info("Stopwatch.stop() method invoke exception.", Arrays.toString(e.getStackTrace()));
+        }
+    }
+
+    /**
+     * 获取秒表的持续时间
+     */
+    public static Long getTime(StopWatch stopWatch) {
+        try {
+            return stopWatch.getTime();
+        } catch (Exception e) {
+            DongTaiLog.info("Stopwatch.getTime() method invoke exception.", Arrays.toString(e.getStackTrace()));
+            return 0L;
+        }
+    }
+
+    /**
+     * 获取开始时间
+     */
+    public static Long getStartTime(StopWatch stopWatch) {
+        try {
+            return stopWatch.getStartTime();
+        } catch (Exception e) {
+            DongTaiLog.info("Stopwatch.getStartTime() method invoke exception.", Arrays.toString(e.getStackTrace()));
+            return null;
+        }
+    }
+
+}


### PR DESCRIPTION
1. fix a bug when switchOpenStatusDurationThreshold value is 0.
Explain: As the return of StopWatch.getTime() is 0 when stopWatch is in UNSTARTED status, switchOpenStatusDurationThreshold need a value bigger than 0. otherwise SecondFallback will be invalid
2. refine Stopwatch operation with try/catch