### PR TITLE
Feature/skip install in low jdk 0329

### DIFF
--- a/dongtai-agent/src/main/java/io/dongtai/iast/agent/AgentLauncher.java
+++ b/dongtai-agent/src/main/java/io/dongtai/iast/agent/AgentLauncher.java
@@ -4,6 +4,7 @@ import io.dongtai.iast.agent.manager.EngineManager;
 import io.dongtai.iast.agent.monitor.impl.EngineMonitor;
 import io.dongtai.iast.agent.monitor.MonitorDaemonThread;
 import io.dongtai.iast.agent.report.AgentRegisterReport;
+import io.dongtai.iast.agent.util.ThreadUtils;
 import io.dongtai.log.DongTaiLog;
 
 import java.lang.instrument.Instrumentation;
@@ -64,6 +65,8 @@ public class AgentLauncher {
             }
             DongTaiLog.info("Engine is about to be uninstalled");
             uninstall();
+            // attach手动卸载后停止守护线程
+            ThreadUtils.killAllDongTaiThreads();
             System.clearProperty("protect.by.dongtai");
         } else {
             if (System.getProperty("protect.by.dongtai", null) != null) {

--- a/dongtai-agent/src/main/java/io/dongtai/iast/agent/monitor/MonitorDaemonThread.java
+++ b/dongtai-agent/src/main/java/io/dongtai/iast/agent/monitor/MonitorDaemonThread.java
@@ -2,6 +2,7 @@ package io.dongtai.iast.agent.monitor;
 
 import io.dongtai.iast.agent.manager.EngineManager;
 import io.dongtai.iast.agent.monitor.impl.*;
+import io.dongtai.iast.common.utils.version.JavaVersionUtils;
 import io.dongtai.log.DongTaiLog;
 
 import java.util.ArrayList;
@@ -60,6 +61,12 @@ public class MonitorDaemonThread implements Runnable {
 
 
     public void startEngine() {
+        // 低版本jdk暂不支持安装引擎core包
+        if (JavaVersionUtils.isJava6() || JavaVersionUtils.isJava7()) {
+            DongTaiLog.info("DongTai Engine core couldn't install because of low JDK version:" + JavaVersionUtils.javaVersionStr());
+            DongTaiLog.info("DongTai IAST started failure");
+            return;
+        }
         // todo: 下载功能优先走本地缓存
         boolean status = engineManager.extractPackage();
         status = status && engineManager.install();

--- a/dongtai-agent/src/main/java/io/dongtai/iast/agent/monitor/MonitorDaemonThread.java
+++ b/dongtai-agent/src/main/java/io/dongtai/iast/agent/monitor/MonitorDaemonThread.java
@@ -16,6 +16,10 @@ public class MonitorDaemonThread implements Runnable {
     public static boolean isExit = false;
     private final EngineManager engineManager;
     public static int delayTime = 0;
+    /**
+     * 引擎是否启动成功
+     */
+    public static boolean engineStartSuccess = false;
 
     public MonitorDaemonThread(EngineManager engineManager) {
         monitorTasks = new ArrayList<IMonitor>();
@@ -48,12 +52,14 @@ public class MonitorDaemonThread implements Runnable {
                 startEngine();
             }
         }
-        // 启动子线程执行monitor任务.
-        for (IMonitor monitor : monitorTasks) {
-            Thread monitorThread = new Thread(monitor, monitor.getName());
-            monitorThread.setDaemon(true);
-            monitorThread.setPriority(1);
-            monitorThread.start();
+        // 引擎启动成功后，创建子线程执行monitor任务
+        if(engineStartSuccess){
+            for (IMonitor monitor : monitorTasks) {
+                Thread monitorThread = new Thread(monitor, monitor.getName());
+                monitorThread.setDaemon(true);
+                monitorThread.setPriority(1);
+                monitorThread.start();
+            }
         }
     }
 
@@ -61,18 +67,29 @@ public class MonitorDaemonThread implements Runnable {
 
 
     public void startEngine() {
-        // 低版本jdk暂不支持安装引擎core包
-        if (JavaVersionUtils.isJava6() || JavaVersionUtils.isJava7()) {
-            DongTaiLog.info("DongTai Engine core couldn't install because of low JDK version:" + JavaVersionUtils.javaVersionStr());
-            DongTaiLog.info("DongTai IAST started failure");
-            return;
-        }
+        boolean status = couldInstallEngine();
         // todo: 下载功能优先走本地缓存
-        boolean status = engineManager.extractPackage();
+        status = status && engineManager.extractPackage();
         status = status && engineManager.install();
         status = status && engineManager.start();
         if (!status) {
             DongTaiLog.info("DongTai IAST started failure");
         }
+        engineStartSuccess = status;
     }
+
+    /**
+     * 是否可以安装引擎
+     *
+     * @return boolean
+     */
+    private boolean couldInstallEngine() {
+        // 低版本jdk暂不支持安装引擎core包
+        if (JavaVersionUtils.isJava6() || JavaVersionUtils.isJava7()) {
+            DongTaiLog.info("DongTai Engine core couldn't install because of low JDK version:" + JavaVersionUtils.javaVersionStr());
+            return false;
+        }
+        return true;
+    }
+
 }

--- a/dongtai-agent/src/main/java/io/dongtai/iast/agent/monitor/impl/DongTaiThreadMonitor.java
+++ b/dongtai-agent/src/main/java/io/dongtai/iast/agent/monitor/impl/DongTaiThreadMonitor.java
@@ -79,15 +79,19 @@ public class DongTaiThreadMonitor implements IMonitor {
 
     @Override
     public void run() {
-        while (!MonitorDaemonThread.isExit) {
-            // 延迟启动DongTaiThreadMonitor，以防首次加载时其他Monitor未能启动的情形出现。
-            ThreadUtils.threadSleep(10);
-            try {
-                this.check();
-            } catch (Throwable t) {
-                DongTaiLog.warn("Monitor thread checked error, monitor:{}, msg:{}, err:{}", getName(), t.getMessage(), t.getCause());
+        try {
+            while (!MonitorDaemonThread.isExit) {
+                // 延迟启动DongTaiThreadMonitor，以防首次加载时其他Monitor未能启动的情形出现。
+                ThreadUtils.threadSleep(10);
+                try {
+                    this.check();
+                } catch (Throwable t) {
+                    DongTaiLog.warn("Monitor thread checked error, monitor:{}, msg:{}, err:{}", getName(), t.getMessage(), t.getCause());
+                }
+                ThreadUtils.threadSleep(50);
             }
-            ThreadUtils.threadSleep(50);
+        } catch (Throwable t) {
+            DongTaiLog.info("DongTaiThreadMonitor interrupted, msg:{}", t.getMessage());
         }
     }
 

--- a/dongtai-agent/src/main/java/io/dongtai/iast/agent/monitor/impl/EngineMonitor.java
+++ b/dongtai-agent/src/main/java/io/dongtai/iast/agent/monitor/impl/EngineMonitor.java
@@ -104,13 +104,17 @@ public class EngineMonitor implements IMonitor {
 
     @Override
     public void run() {
-        while (!MonitorDaemonThread.isExit) {
-            try {
-                this.check();
-            } catch (Throwable t) {
-                DongTaiLog.warn("Monitor thread checked error, monitor:{}, msg:{}, err:{}", getName(), t.getMessage(), t.getCause());
+        try {
+            while (!MonitorDaemonThread.isExit) {
+                try {
+                    this.check();
+                } catch (Throwable t) {
+                    DongTaiLog.warn("Monitor thread checked error, monitor:{}, msg:{}, err:{}", getName(), t.getMessage(), t.getCause());
+                }
+                ThreadUtils.threadSleep(30);
             }
-            ThreadUtils.threadSleep(30);
+        } catch (Throwable t) {
+            DongTaiLog.info("EngineMonitor interrupted, msg:{}", t.getMessage());
         }
     }
 }

--- a/dongtai-agent/src/main/java/io/dongtai/iast/agent/monitor/impl/HeartBeatMonitor.java
+++ b/dongtai-agent/src/main/java/io/dongtai/iast/agent/monitor/impl/HeartBeatMonitor.java
@@ -25,13 +25,17 @@ public class HeartBeatMonitor implements IMonitor {
 
     @Override
     public void run() {
-        while (!MonitorDaemonThread.isExit) {
-            try {
-                this.check();
-            } catch (Throwable t) {
-                DongTaiLog.warn("Monitor thread checked error, monitor:{}, msg:{}, err:{}", getName(), t.getMessage(), t.getCause());
+        try {
+            while (!MonitorDaemonThread.isExit) {
+                try {
+                    this.check();
+                } catch (Throwable t) {
+                    DongTaiLog.warn("Monitor thread checked error, monitor:{}, msg:{}, err:{}", getName(), t.getMessage(), t.getCause());
+                }
+                ThreadUtils.threadSleep(30);
             }
-            ThreadUtils.threadSleep(30);
+        } catch (Throwable t) {
+            DongTaiLog.info("HeartBeatMonitor interrupted, msg:{}", t.getMessage());
         }
     }
 }

--- a/dongtai-agent/src/main/java/io/dongtai/iast/agent/monitor/impl/PerformanceMonitor.java
+++ b/dongtai-agent/src/main/java/io/dongtai/iast/agent/monitor/impl/PerformanceMonitor.java
@@ -247,13 +247,17 @@ public class PerformanceMonitor implements IMonitor {
 
     @Override
     public void run() {
-        while(!MonitorDaemonThread.isExit) {
-            try {
-                this.check();
-            } catch (Throwable t) {
-                DongTaiLog.warn("Monitor thread checked error, monitor:{}, msg:{}, err:{}", getName(), t.getMessage(), t.getCause());
+        try {
+            while (!MonitorDaemonThread.isExit) {
+                try {
+                    this.check();
+                } catch (Throwable t) {
+                    DongTaiLog.warn("Monitor thread checked error, monitor:{}, msg:{}, err:{}", getName(), t.getMessage(), t.getCause());
+                }
+                ThreadUtils.threadSleep(30);
             }
-            ThreadUtils.threadSleep(30);
+        } catch (Throwable t) {
+            DongTaiLog.info("PerformanceMonitor interrupted, msg:{}", t.getMessage());
         }
     }
 }

--- a/dongtai-agent/src/main/java/io/dongtai/iast/agent/monitor/impl/SecondFallbackMonitor.java
+++ b/dongtai-agent/src/main/java/io/dongtai/iast/agent/monitor/impl/SecondFallbackMonitor.java
@@ -44,13 +44,17 @@ public class SecondFallbackMonitor implements IMonitor {
 
     @Override
     public void run() {
-        while (!MonitorDaemonThread.isExit) {
-            try {
-                this.check();
-            } catch (Throwable t) {
-                DongTaiLog.warn("Monitor thread checked error, monitor:{}, msg:{}, err:{}", getName(), t.getMessage(), t.getCause());
+        try {
+            while (!MonitorDaemonThread.isExit) {
+                try {
+                    this.check();
+                } catch (Throwable t) {
+                    DongTaiLog.warn("Monitor thread checked error, monitor:{}, msg:{}, err:{}", getName(), t.getMessage(), t.getCause());
+                }
+                ThreadUtils.threadSleep(60);
             }
-            ThreadUtils.threadSleep(60);
+        } catch (Throwable t) {
+            DongTaiLog.info("SecondFallbackMonitor interrupted, msg:{}", t.getMessage());
         }
     }
 }

--- a/dongtai-agent/src/main/java/io/dongtai/iast/agent/monitor/impl/ServerConfigMonitor.java
+++ b/dongtai-agent/src/main/java/io/dongtai/iast/agent/monitor/impl/ServerConfigMonitor.java
@@ -23,14 +23,18 @@ public class ServerConfigMonitor implements IMonitor {
 
     @Override
     public void run() {
-        while (!MonitorDaemonThread.isExit) {
-            ThreadUtils.threadSleep(60);
-            try {
-                // EngineManger初始化时会请求配置一次，所以ServerConfigMonitor首次不用运行
-                this.check();
-            } catch (Throwable t) {
-                DongTaiLog.warn("Monitor thread checked error, monitor:{}, msg:{}, err:{}", getName(), t.getMessage(), t.getCause());
+        try {
+            while (!MonitorDaemonThread.isExit) {
+                ThreadUtils.threadSleep(60);
+                try {
+                    // EngineManger初始化时会请求配置一次，所以ServerConfigMonitor首次不用运行
+                    this.check();
+                } catch (Throwable t) {
+                    DongTaiLog.warn("Monitor thread checked error, monitor:{}, msg:{}, err:{}", getName(), t.getMessage(), t.getCause());
+                }
             }
+        } catch (Throwable t) {
+            DongTaiLog.info("ServerConfigMonitor interrupted, msg:{}", t.getMessage());
         }
     }
 

--- a/dongtai-agent/src/main/java/io/dongtai/iast/agent/util/ThreadUtils.java
+++ b/dongtai-agent/src/main/java/io/dongtai/iast/agent/util/ThreadUtils.java
@@ -73,6 +73,16 @@ public class ThreadUtils {
         return false;
     }
 
+    /**
+     * 杀死所有的洞态线程
+     */
+    public static void killAllDongTaiThreads() {
+        List<ThreadInfoMetrics.ThreadInfo> dongTaiThreads = ThreadUtils.getDongTaiThreads();
+        for (ThreadInfoMetrics.ThreadInfo each : dongTaiThreads) {
+            ThreadUtils.killDongTaiThread(each.getId());
+        }
+    }
+
     public static void threadSleep(int seconds) {
         try {
             long milliseconds = seconds * 1000L;

--- a/dongtai-agent/src/main/java/io/dongtai/iast/agent/util/ThreadUtils.java
+++ b/dongtai-agent/src/main/java/io/dongtai/iast/agent/util/ThreadUtils.java
@@ -88,8 +88,8 @@ public class ThreadUtils {
             long milliseconds = seconds * 1000L;
             Thread.sleep(milliseconds);
         } catch (InterruptedException e) {
-            DongTaiLog.warn("DongTai thread threadSleep failed, msg: {} , error: {}", e.getMessage(), e.getCause());
             Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
         }
     }
 


### PR DESCRIPTION
+ feat: skip install dongtai-core in `jdk6`/`jdk7`;

+ feat: add engineStartSuccess status in agent `EngineManager`;

+ feat: kill all dongTai threads after uninstall in `agentmain`;

+ fix: check `InterruptedException` in all monitor;